### PR TITLE
Fix -M option

### DIFF
--- a/splatnet2statink.py
+++ b/splatnet2statink.py
@@ -243,7 +243,7 @@ def monitor_battles(s_flag, t_flag, r_flag, secs, debug):
 					printed = True
 					print "Previously-unuploaded battles detected. Uploading now..."
 				post_battle(0, [result], s_flag, t_flag, secs, debug)
-	if not printed:
+	if r_flag and not printed:
 		print "No previously-unuploaded battles found."
 
 	# main process


### PR DESCRIPTION
I found `-M` option is broken when `-r` option is not provided.

```
M:\splatnet2statink>python splatnet2statink.py -M
splatnet2statink v0.0.50
Traceback (most recent call last):
  File "splatnet2statink.py", line 802, in <module>
    monitor_battles(is_s, is_t, is_r, m_value, debug)
  File "splatnet2statink.py", line 247, in monitor_battles
    if not printed:
UnboundLocalError: local variable 'printed' referenced before assignment
```