### PR TITLE
Add Docker support

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:16.04
+MAINTAINER Takeshi HASEGAWA <hasegaw@gmail.com>
+
+RUN apt-get update && apt-get install -y python2.7 python-pip git && pip install requests msgpack-python
+
+RUN git clone -b for-docker https://github.com/frozenpandaman/splatnet2statink.git /var/lib/splatnet2statink
+COPY run.sh /var/lib/splatnet2statink/run.sh
+RUN chmod 755 /var/lib/splatnet2statink/run.sh
+RUN useradd spike && chmod 701 /var/lib/splatnet2statink && chown -R spike:spike /var/lib/splatnet2statink
+
+USER spike
+CMD /var/lib/splatnet2statink/run.sh

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+
+# Parameters (DO NOT MODIFIY!)
+
+INTERVAL=120            # Interval (min) for running
+RETRY_INTERVAL=5        # Interval (min) for temporary errors.  
+RETRIES=3               # Maximum retry count for temporary errors
+UPDATE_INTERVAL=86400   # Inerval (sec) for automatic update. one time/day
+WORKDIR=`dirname $0`
+
+# Initialization
+last_update_time=0
+
+cd $WORKDIR
+[ -e ./run.conf ] && source ./run.conf
+
+
+# Create config.txt
+write_config() {
+    cat > config.txt <<__EOF__
+{
+    "api_key": "${STATINK_API_KEY}",
+    "cookie": "${IKSM_SESSION}",
+    "user_lang": "${USER_LANG}"
+}
+__EOF__
+}
+
+
+# Get latest splatnet2statink from git origin
+self_update() {
+    local current_time
+    local d
+
+    [ -e .git ] || return
+
+    current_time=`/bin/date +%s`
+
+    d=$((${current_time} - ${last_update_time}))
+    [ ${d} -lt ${UPDATE_INTERVAL} ] && return
+
+    echo Updating splatnet2statink
+    git pull
+    last_update_time=${current_time}
+}
+
+
+# Main
+main() {
+    local errorcode
+    local retry
+    retry=0
+
+    # Write config once.
+    write_config
+
+    while true; do
+        # Try self-update
+        self_update
+
+        # Run!
+        python splatnet2statink.py -r
+        errorcode=$?
+
+        if [ ${errorcode} -eq 1 ]; then
+            # permanent error
+            echo "Permanent error. Exiting"
+
+            exit 1
+
+        elif [ ${errorcode} -eq 2 ]; then
+            # temporary error
+
+            retry=$((${retry} + 1))
+            echo "try ${retry} of ${RETRIES}"
+
+                if [ ${retry} -ge ${RETRIES} ]; then
+                    echo "maximum retry count exceeded."
+
+                else
+                    echo "Next retry run in ${RETRY_INTERVAL} minutes later"
+                    sleep $((${RETRY_INTERVAL} * 60))
+                    continue
+                fi
+
+        elif [ ${errorcode} -eq 3 ]; then
+            echo "stat.ink API key is invalid"
+
+            # ToDo: stop running, until the user provides the new IKSM session
+            # Now we finish the container
+            exit 1
+
+        elif [ ${errorcode} -eq 4 ]; then
+            echo "stat.ink API key is invalid"
+
+            # ToDo: stop running, until the user provides the new IKSM session
+            # Now we finish the container
+            exit 1
+            
+        elif [ ${errorcode} -ne 0 ]; then
+            # unexpected exitcode.
+            echo "Unexpected exitcode. Exiting"
+            exit 1
+
+        fi
+        retry=0
+        echo "Next run in ${INTERVAL} minutes later"
+        sleep $((${INTERVAL} * 60))
+    done
+}
+
+
+main


### PR DESCRIPTION
The Dockerfile and the shell script allows running `splatnet2statink` on Docker container.

To build the image:
```
git clone https://github.com/frozenpandaman/splatnet2statink
cd splatnet2statink/docker/
docker build -t splatnet2statink .
```
To run the image:
```
# For test
docker run -it -e IKSM_SESSION=xxxxx -e STATINK_API_KEY=xxxx -e USER_LANG=ja-JP splatnet2statink

# Run in background!
docker run -d -e IKSM_SESSION=xxxxx -e STATINK_API_KEY=xxxx -e USER_LANG=ja-JP splatnet2statink
```

* Note that this Dockerfile always run `git clone` to create the image (doesn't use local working copy.)
* This image will automatically track `for-docker` branch on `frozenpanaman/splatnet2statink` as auto-update feature.