### PR TITLE
Fix UnicodeDecodeError on uploading to stat.ink

### DIFF
--- a/splatnet2statink.py
+++ b/splatnet2statink.py
@@ -683,7 +683,7 @@ def post_battle(i, results, s_flag, t_flag, m_flag, sendgears, debug, ismonitor=
 	principal_id = results[i]["player_result"]["player"]["principal_id"]
 	namespace = uuid.UUID('{73cf052a-fd0b-11e7-a5ee-001b21a098c2}')
 	name = str(bn) + "@" + str(principal_id)
-	payload["uuid"] = str(uuid.uuid5(namespace, name))
+	payload["uuid"] = str(uuid.uuid5(namespace, name.encode("utf-8")))
 
 	##################
 	## LOBBY & MODE ##

--- a/splatnet2statink.py
+++ b/splatnet2statink.py
@@ -20,7 +20,7 @@ from distutils.version import StrictVersion
 from subprocess import call
 # PIL/Pillow imported at bottom
 
-A_VERSION = "0.3.0"
+A_VERSION = "0.3.1"
 
 print("splatnet2statink v" + A_VERSION)
 


### PR DESCRIPTION
I got an error because my handle name includes 2-byte characters.
```
$ ./splatnet2statink.py -r -M 7200
splatnet2statink v0.3.0
Checking if there are previously-unuploaded battles...
Previously-unuploaded battles detected. Uploading now...
Traceback (most recent call last):
  File "./splatnet2statink.py", line 1096, in <module>
    monitor_battles(is_s, is_t, is_r, m_value, debug)
  File "./splatnet2statink.py", line 326, in monitor_battles
    battles = populate_battles(s_flag, t_flag, r_flag, debug)
  File "./splatnet2statink.py", line 308, in populate_battles
    post_battle(0, [result], s_flag, t_flag, -1, False, debug, True)
  File "./splatnet2statink.py", line 686, in post_battle
    payload["uuid"] = str(uuid.uuid5(namespace, name))
  File "/home/tiryoh/.pyenv/versions/2.7.13/lib/python2.7/uuid.py", line 589, in uuid5
    hash = sha1(namespace.bytes + name).digest()
UnicodeDecodeError: 'ascii' codec can't decode byte 0xcf in position 1: ordinal not in range(128)
```