### PR TITLE
Fix Errror: TypeError: '<' not supported between instances of 'NoneType' and 'int'

### DIFF
--- a/splatnet2statink.py
+++ b/splatnet2statink.py
@@ -987,7 +987,7 @@ def post_battle(i, results, s_flag, t_flag, m_flag, sendgears, debug, ismonitor=
 			payload["fest_exp"] = fest_rank_rollover + fest_exp_after - points_gained
 
 		# temp fix
-		if payload["fest_exp"] < 0:
+		if payload["fest_exp"] and payload["fest_exp"] < 0:
 			payload["fest_exp"] = None
 
 	else: # not splatfest


### PR DESCRIPTION
Thank you very much for your scripts.

However, an error occurred when it became "Eternal Takenoko-no-sato girl" at this festival ("Takenoko-no-sato Queen" in English)

# Stacktrace

Python Version: 3.6.6
splatnet2statink Version: 1.6.6

```
splatnet2statink v1.1.6
Pulling data from online...
Number of recent battles to upload (0-50)? 2
Traceback (most recent call last):
  File "c:\Users\user\repos\splatnet2statink-docker\splatnet2statink\splatnet2statink.py", line 1192, in <module>
    post_battle(i, results, is_s, is_t, m_value, True if i == 0 else False, debug)
  File "c:\Users\user\repos\splatnet2statink-docker\splatnet2statink\splatnet2statink.py", line 990, in post_battle
    if payload["fest_exp"] < 0:
TypeError: '<' not supported between instances of 'NoneType' and 'int'
```
When fest_exp is None, I think it is caused by comparison with int type.