### PR TITLE
Fix calculation error of fest_exp when uniform_bonus > 1

### DIFF
--- a/splatnet2statink.py
+++ b/splatnet2statink.py
@@ -992,6 +992,11 @@ def post_battle(i, results, s_flag, t_flag, m_flag, sendgears, debug, ismonitor=
 			elif results[i]["other_estimate_fes_power"] >= 1900:
 				points_gained += 7 * multiplier
 
+		if ver4:
+			uniform_bonus = results[i]["uniform_bonus"]
+			if uniform_bonus > 1:
+				points_gained *= uniform_bonus
+
 		# SPECIAL CASE - KING/QUEEN MAX
 		if title_before == 4 and title_after == 4 and fest_exp_after == 0:
 			payload["fest_exp"] = 0 # already at max, no exp gained


### PR DESCRIPTION
対戦相手のフェスパワーと勝敗からバトル前のフェスポイントを計算していますが、おそろいボーナスが考慮されていないため、おそろいボーナスが発生しているときに、バトル前のフェスポイントが誤っています。

バトル開始前はフェスの称号が「ふつうのトリックガール 0」でしたが、フェスパワー1940の相手に勝利して、おそろいボーナスが1.1だったため、(70+20)*1.1=99ポイント加算されて、「ふつうのトリックガール 99」になりました。

ここからバトル開始前のフェスポイントを計算する際に、おそろいボーナスが考慮されていないため、99-(70+20)=9となり、バトル開始前のフェスの称号が「ふつうのトリックガール 9」になっています。

![image](https://user-images.githubusercontent.com/387175/47215233-a5eef680-d3db-11e8-9f7f-83affce1b0cc.png)