### PR TITLE
catch edge case in setting SR title (before)

### DIFF
--- a/salmonrun.py
+++ b/salmonrun.py
@@ -122,6 +122,8 @@ def salmon_post_shift(i, results):
 		pass # could be legit clear 20->40, or could be rank up ?->40
 	elif title_exp_after == 40 and title_exp_delta < 0 and title_num != 5:
 		pass # could be legit wave 1 fail 60->40, or could be rank down ?->40; not always -20 for loss
+	elif title_exp_after == 999:
+		pass # ? -> 999; not always 20 for gain
 	else: # rank/title did not change
 		payload["title"] = translate_titles[title_num]
 


### PR DESCRIPTION
開始後が「たつじん999」だとカンストしているので、開始前の称号が特定できません。