### PR TITLE
UnicodeEncodeError if acc_name includes non-ascii chars

### DIFF
--- a/splatnet2statink.py
+++ b/splatnet2statink.py
@@ -3,6 +3,7 @@
 
 # eli fessler
 # clovervidia
+from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from builtins import input


### PR DESCRIPTION
The script throws UnicodeEncodeError if acc_name has non-ascii characters, so it would be better to encode it to UTF-8.