### PR TITLE
fix implicit int to string conversion

### DIFF
--- a/splatnet2statink.py
+++ b/splatnet2statink.py
@@ -948,7 +948,7 @@ def post_battle(i, results, s_flag, t_flag, m_flag, sendgears, debug, ismonitor=
 	## SPLATNET DATA ##
 	###################
 	payload["private_note"] = "Battle #{}".format(bn)
-	payload["splatnet_number"] = bn
+	payload["splatnet_number"] = int(bn)
 	if mode == "league":
 		payload["my_team_id"] = results[i]["tag_id"]
 		payload["league_point"] = results[i]["league_point"]


### PR DESCRIPTION
When splatnet2statink sends the splatnet_number data, it sends it as a string (and not as int, as the stat.ink API specifies) due to implicit integer to string conversion. While stat.ink's API seems to work even with the splatnet_number as a string, I think it's best to adhere to the specification if possible.