### PR TITLE
Update App Version to 1.9.0

### DIFF
--- a/iksm.py
+++ b/iksm.py
@@ -81,7 +81,7 @@ def get_session_token(session_token_code, auth_code_verifier):
 	'''Helper function for log_in().'''
 
 	app_head = {
-		'User-Agent':      'OnlineLounge/1.8.0 NASDKAPI Android',
+		'User-Agent':      'OnlineLounge/1.9.0 NASDKAPI Android',
 		'Accept-Language': 'en-US',
 		'Accept':          'application/json',
 		'Content-Type':    'application/x-www-form-urlencoded',
@@ -119,7 +119,7 @@ def get_cookie(session_token, userLang, ver):
 		'Content-Length':  '439',
 		'Accept':          'application/json',
 		'Connection':      'Keep-Alive',
-		'User-Agent':      'OnlineLounge/1.8.0 NASDKAPI Android'
+		'User-Agent':      'OnlineLounge/1.9.0 NASDKAPI Android'
 	}
 
 	body = {
@@ -136,7 +136,7 @@ def get_cookie(session_token, userLang, ver):
 	# get user info
 	try:
 		app_head = {
-			'User-Agent':      'OnlineLounge/1.8.0 NASDKAPI Android',
+			'User-Agent':      'OnlineLounge/1.9.0 NASDKAPI Android',
 			'Accept-Language': userLang,
 			'Accept':          'application/json',
 			'Authorization':   'Bearer {}'.format(id_response["access_token"]),
@@ -160,9 +160,9 @@ def get_cookie(session_token, userLang, ver):
 	app_head = {
 		'Host':             'api-lp1.znc.srv.nintendo.net',
 		'Accept-Language':  userLang,
-		'User-Agent':       'com.nintendo.znca/1.8.0 (Android/7.1.2)',
+		'User-Agent':       'com.nintendo.znca/1.9.0 (Android/7.1.2)',
 		'Accept':           'application/json',
-		'X-ProductVersion': '1.8.0',
+		'X-ProductVersion': '1.9.0',
 		'Content-Type':     'application/json; charset=utf-8',
 		'Connection':       'Keep-Alive',
 		'Authorization':    'Bearer',
@@ -212,9 +212,9 @@ def get_cookie(session_token, userLang, ver):
 	try:
 		app_head = {
 			'Host':             'api-lp1.znc.srv.nintendo.net',
-			'User-Agent':       'com.nintendo.znca/1.8.0 (Android/7.1.2)',
+			'User-Agent':       'com.nintendo.znca/1.9.0 (Android/7.1.2)',
 			'Accept':           'application/json',
-			'X-ProductVersion': '1.8.0',
+			'X-ProductVersion': '1.9.0',
 			'Content-Type':     'application/json; charset=utf-8',
 			'Connection':       'Keep-Alive',
 			'Authorization':    'Bearer {}'.format(splatoon_token["result"]["webApiServerCredential"]["accessToken"]),

--- a/splatnet2statink.py
+++ b/splatnet2statink.py
@@ -21,7 +21,7 @@ from distutils.version import StrictVersion
 from subprocess import call
 # PIL/Pillow imported at bottom
 
-A_VERSION = "1.5.5"
+A_VERSION = "1.5.6"
 
 print("splatnet2statink v{}".format(A_VERSION))
 


### PR DESCRIPTION
This pull request fix following error.

```
splatnet2statink v1.5.5
The stored cookie has expired.
Attempting to generate new cookie...
Error from Nintendo (in Account/Login step):
{
  "status": 9427,
  "correlationId": "xxxxxxxx-xxxxxxxx",
  "errorMessage": "Upgrade required."
}
```