### PR TITLE
avoid using nickname for sort if s_flag

### DIFF
--- a/splatnet2statink.py
+++ b/splatnet2statink.py
@@ -21,7 +21,7 @@ from distutils.version import StrictVersion
 from subprocess import call
 # PIL/Pillow imported at bottom
 
-A_VERSION = "1.5.9"
+A_VERSION = "1.5.10"
 
 print("splatnet2statink v{}".format(A_VERSION))
 

--- a/splatnet2statink.py
+++ b/splatnet2statink.py
@@ -653,9 +653,15 @@ def set_scoreboard(payload, battle_number, mystats, s_flag, battle_payload=None)
 	# scoreboard sort order: sort_score (or turf inked), k+a, specials, deaths (more = better), kills, nickname
 	# discussion: https://github.com/frozenpandaman/splatnet2statink/issues/6
 	if rule != "turf_war":
-		sorted_ally_scoreboard = sorted(ally_scoreboard, key=itemgetter(0, 1, 3, 4, 2, 11), reverse=True)
+		if s_flag:
+			sorted_ally_scoreboard = sorted(ally_scoreboard, key=itemgetter(0, 1, 3, 4, 2), reverse=True)
+		else:
+			sorted_ally_scoreboard = sorted(ally_scoreboard, key=itemgetter(0, 1, 3, 4, 2, 11), reverse=True)
 	else:
-		sorted_ally_scoreboard = sorted(ally_scoreboard, key=itemgetter(8, 1, 3, 4, 2, 11), reverse=True)
+		if s_flag:
+			sorted_ally_scoreboard = sorted(ally_scoreboard, key=itemgetter(8, 1, 3, 4, 2), reverse=True)
+		else:
+			sorted_ally_scoreboard = sorted(ally_scoreboard, key=itemgetter(8, 1, 3, 4, 2, 11), reverse=True)
 
 	for n in range(len(sorted_ally_scoreboard)):
 		if sorted_ally_scoreboard[n][10] == 1: # if it's me, position in sorted list is my rank in team


### PR DESCRIPTION
First of all, thank you for nice script!

When s_flag is true, another team member's nickname is set to None while my nickname is set to string.
That's why in this battle (https://stat.ink/@nu50218/spl2/3675280) this error was caused.

```
Traceback (most recent call last):
  File "/splatnet2statink/splatnet2statink.py", line 1282, in <module>
    populate_battles(is_s, is_t, is_r, debug)
  File "/splatnet2statink/splatnet2statink.py", line 375, in populate_battles
    post_battle(0, [result], s_flag, t_flag, -1, True if i == 0 else False, debug, False)
  File "/splatnet2statink/splatnet2statink.py", line 1092, in post_battle
    payload = set_scoreboard(payload, bn, mystats, s_flag)
  File "/splatnet2statink/splatnet2statink.py", line 658, in set_scoreboard
    sorted_ally_scoreboard = sorted(ally_scoreboard, key=itemgetter(0, 1, 3, 4, 2, 11), reverse=True)
TypeError: '<' not supported between instances of 'NoneType' and 'str'
```