### PR TITLE
Make some functions usable from another programs

### DIFF
--- a/splatnet2statink.py
+++ b/splatnet2statink.py
@@ -1303,3 +1303,7 @@ if __name__ == "__main__":
 				post_battle(i, results, is_s, is_t, m_value, True if i == 0 else False, debug)
 			if debug:
 				print("")
+else:
+    # This script is called as dependency
+    m_value, is_s, is_t, is_r, filename, salmon = 600, True, False, False, "", False
+    from PIL import Image, ImageDraw


### PR DESCRIPTION
Changes to make the program usable from another host program.
* Split post_battle() code to two functions that had two functions (data parsing and stat.ink uploader)
* move splatnet access coe from set_scoreboard() to post_battle() to make the data parsing function reusable. 
* Initialize some variables and import PIL to avoid undefined variables reference  if splatnet2statink is imported by another host progiram.