### PR TITLE
Generate the `timestamp` and `request_id` parameters using the imink API

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "**/config.txt": "json"
+    }
+}

--- a/iksm.py
+++ b/iksm.py
@@ -195,7 +195,7 @@ def get_cookie(session_token, userLang, ver):
 
 	body = {}
 	try:
-		idToken = id_response["access_token"]
+		idToken = id_response["id_token"]
 
 		f = call_imink_api(idToken, 1)
 

--- a/splatnet2statink.py
+++ b/splatnet2statink.py
@@ -24,7 +24,7 @@ except ModuleNotFoundError as e:
 from subprocess import call
 # PIL/Pillow imported at bottom
 
-A_VERSION = "1.8.1"
+A_VERSION = "1.8.2"
 
 print("splatnet2statink v{}".format(A_VERSION))
 


### PR DESCRIPTION
This is the full fix for Nintendo's API validation changes yesterday (https://github.com/frozenpandaman/splatnet2statink/issues/143), now the imink API has been updated.

*Wow I did Python code and it worked.* :smile: